### PR TITLE
Fix build for go 1.13.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ def buildDate = new Date().format("yyyy-MM-dd_HH:mm:ss.sss_Z", TimeZone.getTimeZ
 def ldflags = "-ldflags \"-X main.branch=${gitBranch} -X main.commit=${gitCommit} -X main.date=${buildDate}\""
 
 build {
+  environment GO111MODULE: 'off'
   go "build ${ldflags} -o ${project.binDir}/${project.execName} ${project.packageRepo}/${project.execName}"
 }
 

--- a/build.sh
+++ b/build.sh
@@ -36,6 +36,7 @@ fi
 export GO15VENDOREXPERIMENT=1
 export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/${GOGRADLE_PROJECT_PATH}
+export GO111MODULE=off
 
 echo "Building $exec_name"
 go install -ldflags "${LDFLAGS}" "$@" ${repo_path}/${exec_name}


### PR DESCRIPTION
In go 1.13, modules are enabled by default even if building inside
GOPATH. Add environment variable to disable modules.