### PR TITLE
Fix kactus panic and recover from panic

### DIFF
--- a/vendor/github.com/kaloom/kubernetes-common/gset/gset.go
+++ b/vendor/github.com/kaloom/kubernetes-common/gset/gset.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2017-2019 Kaloom Inc.
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gset
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// Builder is a mutable builder for GSet (Generic Set). Functions that
+// mutate instances of this type are not thread-safe.
+type Builder struct {
+	result GSet
+	done   bool
+}
+
+// GValue a value object associated with the set element name
+type GValue interface{}
+
+// GSet is a thread-safe, immutable set-like data structure for names (strings)
+type GSet struct {
+	elems map[string]GValue
+}
+
+// KV a key/val for GSet where the key is the set element name
+type KV struct {
+	Key string
+	Val GValue
+}
+
+// NewBuilder returns a mutable GSet builder.
+func NewBuilder() Builder {
+	return Builder{
+		result: GSet{
+			elems: map[string]GValue{},
+		},
+	}
+}
+
+// Add adds the supplied elements to the result. Calling Add after calling
+// Result has no effect.
+func (b Builder) Add(key string, value GValue) {
+	if b.done {
+		return
+	}
+	b.result.elems[key] = value
+}
+
+// Result returns the result GSet containing all elements that were
+// previously added to this builder. Subsequent calls to Add have no effect.
+func (b Builder) Result() GSet {
+	b.done = true
+	return b.result
+}
+
+// NewGSet returns a new GSet containing the supplied elements.
+func NewGSet(elems ...KV) GSet {
+	b := NewBuilder()
+	for _, kv := range elems {
+		b.Add(kv.Key, kv.Val)
+	}
+	return b.Result()
+}
+
+// Size returns the number of elements in this set.
+func (s GSet) Size() int {
+	return len(s.elems)
+}
+
+// IsEmpty returns true if there are zero elements in this set.
+func (s GSet) IsEmpty() bool {
+	return s.Size() == 0
+}
+
+// Contains returns true if the supplied element is present in this set.
+func (s GSet) Contains(net string) bool {
+	_, found := s.elems[net]
+	return found
+}
+
+// Equals returns true if the supplied set contains exactly the same elements
+// as this set (s IsSubsetOf s2 and s2 IsSubsetOf s).
+func (s GSet) Equals(s2 GSet) bool {
+	return reflect.DeepEqual(s.elems, s2.elems)
+}
+
+// Filter returns a new G set that contains all of the elements from this
+// set that match the supplied predicate, without mutating the source set.
+func (s GSet) Filter(predicate func(string) bool) GSet {
+	b := NewBuilder()
+	for net := range s.elems {
+		if predicate(net) {
+			b.Add(net, s.elems[net])
+		}
+	}
+	return b.Result()
+}
+
+// FilterNot returns a new G set that contains all of the elements from this
+// set that do not match the supplied predicate, without mutating the source
+// set.
+func (s GSet) FilterNot(predicate func(string) bool) GSet {
+	b := NewBuilder()
+	for net := range s.elems {
+		if !predicate(net) {
+			b.Add(net, s.elems[net])
+		}
+	}
+	return b.Result()
+}
+
+// IsSubsetOf returns true if the supplied set contains all the elements
+func (s GSet) IsSubsetOf(s2 GSet) bool {
+	result := true
+	for net := range s.elems {
+		if !s2.Contains(net) {
+			result = false
+			break
+		}
+	}
+	return result
+}
+
+// Union returns a new G set that contains all of the elements from this
+// set and all of the elements from the supplied set, without mutating
+// either source set.
+func (s GSet) Union(s2 GSet) GSet {
+	b := NewBuilder()
+	for net := range s.elems {
+		b.Add(net, s.elems[net])
+	}
+	for net := range s2.elems {
+		b.Add(net, s2.elems[net])
+	}
+	return b.Result()
+}
+
+// Intersection returns a new G set that contains all of the elements
+// that are present in both this set and the supplied set, without mutating
+// either source set.
+func (s GSet) Intersection(s2 GSet) GSet {
+	return s.Filter(func(net string) bool { return s2.Contains(net) })
+}
+
+// Difference returns a new G set that contains all of the elements that
+// are present in this set and not the supplied set, without mutating either
+// source set.
+func (s GSet) Difference(s2 GSet) GSet {
+	return s.FilterNot(func(net string) bool { return s2.Contains(net) })
+}
+
+// ToSlice returns a slice of KV that contains all elements from
+// this set.
+func (s GSet) ToSlice() KVSlice {
+	result := KVSlice{}
+	for net := range s.elems {
+		result = append(result, KV{net, s.elems[net]})
+	}
+	sort.Sort(result)
+	return result
+}
+
+// String returns a new string representation of the elements in this G set
+func (s GSet) String() string {
+	if s.IsEmpty() {
+		return ""
+	}
+
+	// construct string from elems
+	var result bytes.Buffer
+	for _, e := range s.ToSlice() {
+		result.WriteString("{")
+		result.WriteString(e.Key)
+		result.WriteString(",")
+		result.WriteString(fmt.Sprintf("%v", e.Val))
+		result.WriteString("}")
+		result.WriteString(",")
+	}
+	return strings.TrimRight(result.String(), ",")
+}
+
+// Clone returns a copy of this G set.
+func (s GSet) Clone() GSet {
+	b := NewBuilder()
+	for elem := range s.elems {
+		b.Add(elem, s.elems[elem])
+	}
+	return b.Result()
+}
+
+// KVSlice a slice of KV
+type KVSlice []KV
+
+// Len implements KVSlice's Len method for the Sort interface
+func (kv KVSlice) Len() int {
+	return len(kv)
+}
+
+// Swap implements KVSlice's Swap method for the Sort interface
+func (kv KVSlice) Swap(i, j int) {
+	kv[i].Key, kv[j].Key = kv[j].Key, kv[i].Key
+	kv[i].Val, kv[j].Val = kv[j].Val, kv[i].Val
+}
+
+// Less implements KVSlice's Less method for the Sort interface
+func (kv KVSlice) Less(i, j int) bool {
+	return kv[i].Key < kv[j].Key
+}

--- a/vendor/github.com/kaloom/kubernetes-common/gset/gset_test.go
+++ b/vendor/github.com/kaloom/kubernetes-common/gset/gset_test.go
@@ -1,0 +1,301 @@
+/*
+Copyright 2017-2019 Kaloom Inc.
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gset
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGSetBuilder(t *testing.T) {
+	b := NewBuilder()
+	elems := []string{"net1", "net2", "net3", "net4", "net5"}
+	for _, elem := range elems {
+		b.Add(elem, "")
+	}
+	result := b.Result()
+	for _, elem := range elems {
+		if !result.Contains(elem) {
+			t.Fatalf("expected netset to contain element %s: [%v]", elem, result)
+		}
+	}
+	if len(elems) != result.Size() {
+		t.Fatalf("expected netset %s to have the same size as %v", result, elems)
+	}
+}
+
+func TestGSetSize(t *testing.T) {
+	testCases := []struct {
+		netset   GSet
+		expected int
+	}{
+		{NewGSet(), 0},
+		{NewGSet(KV{"net5", ""}), 1},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), 5},
+	}
+
+	for _, c := range testCases {
+		actual := c.netset.Size()
+		if actual != c.expected {
+			t.Fatalf("expected: %d, actual: %d, netset: [%v]", c.expected, actual, c.netset)
+		}
+	}
+}
+
+func TestGSetIsEmpty(t *testing.T) {
+	testCases := []struct {
+		netset   GSet
+		expected bool
+	}{
+		{NewGSet(), true},
+		{NewGSet(KV{"net5", ""}), false},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), false},
+	}
+
+	for _, c := range testCases {
+		actual := c.netset.IsEmpty()
+		if actual != c.expected {
+			t.Fatalf("expected: %t, IsEmpty() returned: %t, netset: [%v]", c.expected, actual, c.netset)
+		}
+	}
+}
+
+func TestGSetContains(t *testing.T) {
+	testCases := []struct {
+		netset         GSet
+		mustContain    []string
+		mustNotContain []string
+	}{
+		{NewGSet(), []string{}, []string{"net1", "net2", "net3", "net4", "net5"}},
+		{NewGSet(KV{"net5", ""}), []string{"net5"}, []string{"net1", "net2", "net3", "net4"}},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net4", ""}, KV{"net5", ""}), []string{"net1", "net2", "net4", "net5"}, []string{"0", "net3", "6"}},
+	}
+
+	for _, c := range testCases {
+		for _, elem := range c.mustContain {
+			if !c.netset.Contains(elem) {
+				t.Fatalf("expected netset to contain element %s: [%v]", elem, c.netset)
+			}
+		}
+		for _, elem := range c.mustNotContain {
+			if c.netset.Contains(elem) {
+				t.Fatalf("expected netset not to contain element %s: [%v]", elem, c.netset)
+			}
+		}
+	}
+}
+
+func TestGSetEqual(t *testing.T) {
+	shouldEqual := []struct {
+		s1 GSet
+		s2 GSet
+	}{
+		{NewGSet(), NewGSet()},
+		{NewGSet(KV{"net5", ""}), NewGSet(KV{"net5", ""})},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""})},
+	}
+
+	shouldNotEqual := []struct {
+		s1 GSet
+		s2 GSet
+	}{
+		{NewGSet(), NewGSet(KV{"net5", ""})},
+		{NewGSet(KV{"net5", ""}), NewGSet()},
+		{NewGSet(), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""})},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet()},
+		{NewGSet(KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""})},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net5", ""})},
+	}
+
+	for _, c := range shouldEqual {
+		if !c.s1.Equals(c.s2) {
+			t.Fatalf("expected netsets to be equal: s1: [%v], s2: [%v]", c.s1, c.s2)
+		}
+	}
+	for _, c := range shouldNotEqual {
+		if c.s1.Equals(c.s2) {
+			t.Fatalf("expected netsets to not be equal: s1: [%v], s2: [%v]", c.s1, c.s2)
+		}
+	}
+}
+
+func TestGSetIsSubsetOf(t *testing.T) {
+	shouldBeSubset := []struct {
+		s1 GSet
+		s2 GSet
+	}{
+		// A set is a subset of itself
+		{NewGSet(), NewGSet()},
+		{NewGSet(KV{"net5", ""}), NewGSet(KV{"net5", ""})},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""})},
+
+		// Empty set is a subset of every set
+		{NewGSet(), NewGSet(KV{"net5", ""})},
+		{NewGSet(), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""})},
+
+		{NewGSet(KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""})},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""})},
+		{NewGSet(KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""})},
+		{NewGSet(KV{"net2", ""}, KV{"net3", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""})},
+	}
+
+	shouldNotBeSubset := []struct {
+		s1 GSet
+		s2 GSet
+	}{}
+
+	for _, c := range shouldBeSubset {
+		if !c.s1.IsSubsetOf(c.s2) {
+			t.Fatalf("expected s1 to be a subset of s2: s1: [%v], s2: [%v]", c.s1, c.s2)
+		}
+	}
+	for _, c := range shouldNotBeSubset {
+		if c.s1.IsSubsetOf(c.s2) {
+			t.Fatalf("expected s1 to not be a subset of s2: s1: [%v], s2: [%v]", c.s1, c.s2)
+		}
+	}
+}
+
+func TestGSetUnion(t *testing.T) {
+	testCases := []struct {
+		s1       GSet
+		s2       GSet
+		expected GSet
+	}{
+		{NewGSet(), NewGSet(), NewGSet()},
+
+		{NewGSet(), NewGSet(KV{"net5", ""}), NewGSet(KV{"net5", ""})},
+		{NewGSet(KV{"net5", ""}), NewGSet(), NewGSet(KV{"net5", ""})},
+		{NewGSet(KV{"net5", ""}), NewGSet(KV{"net5", ""}), NewGSet(KV{"net5", ""})},
+
+		{NewGSet(), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""})},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""})},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""})},
+
+		{NewGSet(KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""})},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""})},
+
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}), NewGSet(KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""})},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}), NewGSet(KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""})},
+	}
+
+	for _, c := range testCases {
+		result := c.s1.Union(c.s2)
+		if !result.Equals(c.expected) {
+			t.Fatalf("expected the union of s1 and s2 to be [%v] (got [%v]), s1: [%v], s2: [%v]", c.expected, result, c.s1, c.s2)
+		}
+	}
+}
+
+func TestGSetIntersection(t *testing.T) {
+	testCases := []struct {
+		s1       GSet
+		s2       GSet
+		expected GSet
+	}{
+		{NewGSet(), NewGSet(), NewGSet()},
+
+		{NewGSet(), NewGSet(KV{"net5", ""}), NewGSet()},
+		{NewGSet(KV{"net5", ""}), NewGSet(), NewGSet()},
+		{NewGSet(KV{"net5", ""}), NewGSet(KV{"net5", ""}), NewGSet(KV{"net5", ""})},
+
+		{NewGSet(), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet()},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(), NewGSet()},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""})},
+
+		{NewGSet(KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net5", ""})},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net5", ""}), NewGSet(KV{"net5", ""})},
+
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}), NewGSet(KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet()},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}), NewGSet(KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net3", ""})},
+	}
+
+	for _, c := range testCases {
+		result := c.s1.Intersection(c.s2)
+		if !result.Equals(c.expected) {
+			t.Fatalf("expected the intersection of s1 and s2 to be [%v] (got [%v]), s1: [%v], s2: [%v]", c.expected, result, c.s1, c.s2)
+		}
+	}
+}
+
+func TestGSetDifference(t *testing.T) {
+	testCases := []struct {
+		s1       GSet
+		s2       GSet
+		expected GSet
+	}{
+		{NewGSet(), NewGSet(), NewGSet()},
+
+		{NewGSet(), NewGSet(KV{"net5", ""}), NewGSet()},
+		{NewGSet(KV{"net5", ""}), NewGSet(), NewGSet(KV{"net5", ""})},
+		{NewGSet(KV{"net5", ""}), NewGSet(KV{"net5", ""}), NewGSet()},
+
+		{NewGSet(), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet()},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""})},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet()},
+
+		{NewGSet(KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet()},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""})},
+
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}), NewGSet(KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""})},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}), NewGSet(KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), NewGSet(KV{"net1", ""}, KV{"net2", ""})},
+	}
+
+	for _, c := range testCases {
+		result := c.s1.Difference(c.s2)
+		if !result.Equals(c.expected) {
+			t.Fatalf("expected the difference of s1 and s2 to be [%v] (got [%v]), s1: [%v], s2: [%v]", c.expected, result, c.s1, c.s2)
+		}
+	}
+}
+
+func TestGSetToSlice(t *testing.T) {
+	testCases := []struct {
+		set      GSet
+		expected KVSlice
+	}{
+		{NewGSet(), KVSlice{}},
+		{NewGSet(KV{"net5", ""}), KVSlice{KV{"net5", ""}}},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), KVSlice{KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}}},
+	}
+
+	for _, c := range testCases {
+		result := c.set.ToSlice()
+		if !reflect.DeepEqual(result, c.expected) {
+			t.Fatalf("expected set as slice to be [%v] (got [%v]), s: [%v]", c.expected, result, c.set)
+		}
+	}
+}
+
+func TestGSetString(t *testing.T) {
+	testCases := []struct {
+		set      GSet
+		expected string
+	}{
+		{NewGSet(), ""},
+		{NewGSet(KV{"net5", ""}), "{net5,}"},
+		{NewGSet(KV{"net1", ""}, KV{"net2", ""}, KV{"net3", ""}, KV{"net4", ""}, KV{"net5", ""}), "{net1,},{net2,},{net3,},{net4,},{net5,}"},
+	}
+
+	for _, c := range testCases {
+		result := c.set.String()
+		if result != c.expected {
+			t.Fatalf("expected set as string to be %s (got \"%s\"), s: [%v]", c.expected, result, c.set)
+		}
+	}
+}

--- a/vendor/github.com/kaloom/kubernetes-common/knf/knf.go
+++ b/vendor/github.com/kaloom/kubernetes-common/knf/knf.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2018-2019 Kaloom Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package knf
+
+import (
+	"net"
+)
+
+// Define an iota of KvsErrors' key map
+const (
+	ErrNoPort = iota
+	ErrAlreadyExists
+	ErrSourceIPforKTEP
+	ErrNoL2NetworkFound
+)
+
+var (
+	// KvsErrors is a map of error messages from kvs, we should've
+	// have an iota of error messages in kvs and use them used
+	// instead of this map and trying to guess what's the error is
+	KvsErrors = map[int]string{
+		ErrNoPort:           "No port",
+		ErrAlreadyExists:    "already exists",
+		ErrSourceIPforKTEP:  "source IP configured on KTEP",
+		ErrNoL2NetworkFound: "No L2 network found",
+	}
+)
+
+// NetworkConf is knf cni-plugin netconf parameters
+type NetworkConf struct {
+	Master             string   `json:"master"`
+	KNID               uint64   `json:"knid"`
+	ParticipatingNodes []net.IP `json:"participatingNodes"`
+	MTU                int      `json:"mtu"`
+	NAT                bool     `json:"nat"`
+	GWPort             string   `json:"gwPort"`
+}

--- a/vendor/github.com/kaloom/kubernetes-common/network.go
+++ b/vendor/github.com/kaloom/kubernetes-common/network.go
@@ -30,11 +30,12 @@ const (
 // NetworkConfig is a struct of the Pod's annotations networks element
 // (a json array of NetworkConfig)
 type NetworkConfig struct {
-	NetworkName string   `json:"name"`                  // required parameter: the network name for the CRD network resource in k8s
-	IfMAC       string   `json:"ifMac,omitempty"`       // optional parameter: the network device mac address in the form of 00:11:22:33:44:55
-	IsPrimary   bool     `json:"isPrimary,omitempty"`   // optional parameter: specify that this network is associated with the primary device in the Pod i.e. eth0
-	UpperLayers []string `json:"upperLayers,omitempty"` // optional parameter: specify the upper layers for this network i.e. a hierarchy in which this network is a lower layer of another network(s)
-	Namespace   string   `json:"namespace,omitempty"`   // optional parameter: the namespace to which this network belongs to, if not specified it would be the namespace of the pod
+	NetworkName  string   `json:"name"`                   // required parameter: the network name for the CRD network resource in k8s
+	IfMAC        string   `json:"ifMac,omitempty"`        // optional parameter: the network device mac address in the form of 00:11:22:33:44:55
+	IsPrimary    bool     `json:"isPrimary,omitempty"`    // optional parameter: specify that this network is associated with the primary device in the Pod i.e. eth0
+	UpperLayers  []string `json:"upperLayers,omitempty"`  // optional parameter: specify the upper layers for this network i.e. a hierarchy in which this network is a lower layer of another network(s)
+	Namespace    string   `json:"namespace,omitempty"`    // optional parameter: the namespace to which this network belongs to, if not specified it would be the namespace of the pod
+	PodagentSkip bool     `json:"podagentSkip,omitempty"` // optional parameter: if true, then podagent won't try to configure this network
 }
 
 // GetNetworkIfname from a networkName return a device name by


### PR DESCRIPTION
The intended behavior was to skip getting the resourceMap if pod was not there, but we didn't check the right thing. Pod could be nil. So I've added a nil check.

kactus also recovers panics so that it exits cleanly now (eg: when called from podagent). This way, we get the error message from podagent.

Changed the code for early return style.